### PR TITLE
enhancement: Ability to set gRPC stats handler

### DIFF
--- a/cerbos/grpc.go
+++ b/cerbos/grpc.go
@@ -30,6 +30,7 @@ import (
 var _ Client[*GRPCClient, PrincipalCtx] = (*GRPCClient)(nil)
 
 type config struct {
+	statsHandler       stats.Handler
 	address            string
 	tlsAuthority       string
 	tlsCACert          string
@@ -44,7 +45,6 @@ type config struct {
 	maxRetries         uint
 	plaintext          bool
 	tlsInsecure        bool
-	statsHandler       stats.Handler
 }
 
 type Opt func(*config)


### PR DESCRIPTION
Otel library has finally moved to using `stats.Handler` to record gRPC
traces and metrics. This means that we need a way for users to set a
`stats.Handler` on the connection established by the Cerbos client.

Signed-off-by: Charith Ellawala <charith@cerbos.dev>
